### PR TITLE
docs: update DocumentationUrl in appsettings.json

### DIFF
--- a/src/Rocket.Web.Host/appsettings.json
+++ b/src/Rocket.Web.Host/appsettings.json
@@ -10,6 +10,6 @@
   },
   "AllowedHosts": "*",
   "SiteConfigurationOptions": {
-    "DocumentationUrl": "https://gman-au.github.io/bottle-rocket-documentation/docs/docs-general/overview"
+    "DocumentationUrl": "https://gman-au.github.io/bottle-rocket-documentation/"
   }
 }


### PR DESCRIPTION
Simplified the DocumentationUrl to remove redundant path segments. This ensures better maintainability and avoids potential broken links in the future.