### PR TITLE
chore: add JsonPropertyName attributes to API contract classes closes #3

### DIFF
--- a/src/Rocket.Api.Contracts/AccountLoginRequest.cs
+++ b/src/Rocket.Api.Contracts/AccountLoginRequest.cs
@@ -1,9 +1,13 @@
-﻿namespace Rocket.Api.Contracts
+﻿using System.Text.Json.Serialization;
+
+namespace Rocket.Api.Contracts
 {
     public class AccountLoginRequest
     {
+        [JsonPropertyName("user_name")]
         public string Username { get; set; }
 
+        [JsonPropertyName("password")]
         public string Password { get; set; }
     }
 }

--- a/src/Rocket.Api.Contracts/ConnectionTestResponse.cs
+++ b/src/Rocket.Api.Contracts/ConnectionTestResponse.cs
@@ -1,9 +1,13 @@
-﻿namespace Rocket.Api.Contracts
+﻿using System.Text.Json.Serialization;
+
+namespace Rocket.Api.Contracts
 {
     public class ConnectionTestResponse : ApiResponse
     {
+        [JsonPropertyName("user_name")]
         public string UserName { get; set; }
         
+        [JsonPropertyName("role")]
         public string Role { get; set; }
     }
 }

--- a/src/Rocket.Api.Contracts/CreateUserRequest.cs
+++ b/src/Rocket.Api.Contracts/CreateUserRequest.cs
@@ -1,11 +1,16 @@
-﻿namespace Rocket.Api.Contracts
+﻿using System.Text.Json.Serialization;
+
+namespace Rocket.Api.Contracts
 {
     public class CreateUserRequest
     {
+        [JsonPropertyName("user_name")]
         public string Username { get; set; }
         
+        [JsonPropertyName("password")]
         public string Password { get; set; }
         
+        [JsonPropertyName("is_the_new_admin")]
         public bool IsTheNewAdmin { get; set; }
     }
 }

--- a/src/Rocket.Api.Contracts/CreateUserResponse.cs
+++ b/src/Rocket.Api.Contracts/CreateUserResponse.cs
@@ -1,9 +1,13 @@
-﻿namespace Rocket.Api.Contracts
+﻿using System.Text.Json.Serialization;
+
+namespace Rocket.Api.Contracts
 {
     public class CreateUserResponse : ApiResponse
     {
+        [JsonPropertyName("user_name")]
         public string Username { get; set; }
 
+        [JsonPropertyName("created_at")]
         public System.DateTime CreatedAt { get; set; }
     }
 }

--- a/src/Rocket.Api.Contracts/FetchUsersRequest.cs
+++ b/src/Rocket.Api.Contracts/FetchUsersRequest.cs
@@ -1,9 +1,13 @@
-﻿namespace Rocket.Api.Contracts
+﻿using System.Text.Json.Serialization;
+
+namespace Rocket.Api.Contracts
 {
     public class FetchUsersRequest
     {
+        [JsonPropertyName("start_index")]
         public int StartIndex { get; set; }
         
+        [JsonPropertyName("record_count")]
         public int RecordCount { get; set; }
     }
 }

--- a/src/Rocket.Api.Contracts/FetchUsersResponse.cs
+++ b/src/Rocket.Api.Contracts/FetchUsersResponse.cs
@@ -1,11 +1,14 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Rocket.Api.Contracts
 {
     public class FetchUsersResponse : ApiResponse
     {
+        [JsonPropertyName("users")]
         public IEnumerable<UserItem> Users { get; set; }
         
+        [JsonPropertyName("total_records")]
         public int TotalRecords { get; set; }
     }
 }

--- a/src/Rocket.Api.Contracts/MyScanItem.cs
+++ b/src/Rocket.Api.Contracts/MyScanItem.cs
@@ -1,15 +1,20 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 
 namespace Rocket.Api.Contracts
 {
     public class MyScanItem
     {
+        [JsonPropertyName("id")]
         public string Id { get; set; }
         
+        [JsonPropertyName("date_scanned")]
         public DateTime DateScanned { get; set; }
         
+        [JsonPropertyName("content_type")]
         public string ContentType { get; set; }
         
+        [JsonPropertyName("thumbnail_base64")]
         public string ThumbnailBase64 { get; set; }
     }
 }

--- a/src/Rocket.Api.Contracts/MyScanItemDetail.cs
+++ b/src/Rocket.Api.Contracts/MyScanItemDetail.cs
@@ -5,20 +5,28 @@ namespace Rocket.Api.Contracts
 {
     public class MyScanItemDetail : ApiResponse
     {
+        [JsonPropertyName("id")]
         public string Id { get; set; }
+        
+        [JsonPropertyName("user_id")]
         public string UserId { get; set; }
 
-        //[JsonPropertyName("capture_date")]
+        [JsonPropertyName("capture_date")]
         public DateTime? CaptureDate { get; set; }
         
+        [JsonPropertyName("blob_id")]
         public string BlobId { get; set; }
         
+        [JsonPropertyName("content_type")]
         public string ContentType { get; set; }
         
+        [JsonPropertyName("file_extension")]
         public string FileExtension { get; set; }
         
+        [JsonPropertyName("sha_256")]
         public string Sha256 { get; set; }
         
+        [JsonPropertyName("image_base64")]
         public string ImageBase64 { get; set; }
     }
 }

--- a/src/Rocket.Api.Contracts/MyScansRequest.cs
+++ b/src/Rocket.Api.Contracts/MyScansRequest.cs
@@ -1,9 +1,13 @@
-﻿namespace Rocket.Api.Contracts
+﻿using System.Text.Json.Serialization;
+
+namespace Rocket.Api.Contracts
 {
     public class MyScansRequest
     {
+        [JsonPropertyName("start_index")]
         public int StartIndex { get; set; }
         
+        [JsonPropertyName("record_count")]
         public int RecordCount { get; set; }
     }
 }

--- a/src/Rocket.Api.Contracts/MyScansResponse.cs
+++ b/src/Rocket.Api.Contracts/MyScansResponse.cs
@@ -1,11 +1,14 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Rocket.Api.Contracts
 {
     public class MyScansResponse : ApiResponse
     {
+        [JsonPropertyName("scans")]
         public IEnumerable<MyScanItem> Scans { get; set; }
         
+        [JsonPropertyName("total_records")]
         public int TotalRecords { get; set; }
     }
 }

--- a/src/Rocket.Api.Contracts/StartupPhaseResponse.cs
+++ b/src/Rocket.Api.Contracts/StartupPhaseResponse.cs
@@ -1,7 +1,10 @@
-﻿namespace Rocket.Api.Contracts
+﻿using System.Text.Json.Serialization;
+
+namespace Rocket.Api.Contracts
 {
     public class StartupPhaseResponse : ApiResponse
     {
+        [JsonPropertyName("phase")]
         public int Phase { get; set; }
     }
 }

--- a/src/Rocket.Api.Contracts/UserDetail.cs
+++ b/src/Rocket.Api.Contracts/UserDetail.cs
@@ -1,21 +1,29 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 
 namespace Rocket.Api.Contracts
 {
     public class UserDetail : ApiResponse
     {
+        [JsonPropertyName("id")]
         public string Id { get; set; }
         
+        [JsonPropertyName("user_name")]
         public string Username { get; set; }
         
+        [JsonPropertyName("created_at")]
         public DateTime? CreatedAt { get; set; }
         
+        [JsonPropertyName("last_login_at")]
         public DateTime? LastLoginAt { get; set; }
         
+        [JsonPropertyName("is_active")]
         public bool? IsActive { get; set; }
         
+        [JsonPropertyName("is_admin")]
         public bool? IsAdmin { get; set; }
         
+        [JsonPropertyName("new_password")]
         public string NewPassword { get; set; }
     }
 }

--- a/src/Rocket.Api.Contracts/UserItem.cs
+++ b/src/Rocket.Api.Contracts/UserItem.cs
@@ -1,13 +1,17 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 
 namespace Rocket.Api.Contracts
 {
     public class UserItem
     {
+        [JsonPropertyName("id")]
         public string Id { get; set; }
         
+        [JsonPropertyName("user_name")]
         public string Username { get; set; }
         
+        [JsonPropertyName("created_at")]
         public DateTime? CreatedAt { get; set; }
     }
 }

--- a/src/Rocket.Tests.Unit/ApiRequestManagerTests.cs
+++ b/src/Rocket.Tests.Unit/ApiRequestManagerTests.cs
@@ -123,12 +123,12 @@ namespace Rocket.Tests.Unit
                                                   "id": "abcdef",
                                                   "error_code": "0", 
                                                   "error_message": "no error",
-                                                  "CaptureDate": "1909-01-01T00:00:00Z",
-                                                  "BlobId": "923874ab3",
-                                                  "ContentType": "image/jpeg",
-                                                  "FileExtension": ".jpg",
-                                                  "Sha256": "238736df872a",
-                                                  "ImageBase64": "yyy==m"
+                                                  "capture_date": "1909-01-01T00:00:00Z",
+                                                  "blob_id": "923874ab3",
+                                                  "content_type": "image/jpeg",
+                                                  "file_extension": ".jpg",
+                                                  "sha_256": "238736df872a",
+                                                  "image_base64": "yyy==m"
                                                   }
                                                   """;
                 SetupApiResponseWithHttpCode(HttpStatusCode.OK);


### PR DESCRIPTION
Mapped class properties to JSON field names using `JsonPropertyName` attributes to ensure proper serialization and deserialization. Updated the affected test cases to match the updated JSON naming convention.