### PR TITLE
Add Fusion V16 product template code

### DIFF
--- a/src/Rocket.Domain/Enum/RocketbookProductTypeEnum.cs
+++ b/src/Rocket.Domain/Enum/RocketbookProductTypeEnum.cs
@@ -2,6 +2,7 @@
 {
     public enum RocketbookProductTypeEnum
     {
+        FusionV16 = 0x16,
         Fusion = 0x1F,
         Core = 0x17
     }


### PR DESCRIPTION
Hi,

I met the same issue discussed at https://github.com/gman-au/bottle-rocket-android/issues/21

I used OpenAI/Codex to help me to resolve the issue and it works (you need to build the docker image again (bottle-rocket-api).

**Motivation**
Add support for a Fusion V16 product identifier so prepopulation can generate V16 templates/QR codes while preserving the existing Fusion value for backward compatibility.

**Description**
Add FusionV16 = 0x16 to src/Rocket.Domain/Enum/RocketbookProductTypeEnum.cs and keep the existing Fusion entry.