### PR TITLE
fix: add support for Rocketbook product type codes #80

### DIFF
--- a/src/Rocket.Api.Host/Extensions/RocketbookProductTypeEnumEx.cs
+++ b/src/Rocket.Api.Host/Extensions/RocketbookProductTypeEnumEx.cs
@@ -1,0 +1,21 @@
+﻿using Rocket.Domain.Enum;
+
+namespace Rocket.Api.Host.Extensions
+{
+    public static class RocketbookProductTypeEnumEx
+    {
+        public static string ToCode(this RocketbookProductTypeEnum value)
+        {
+            var result = (ushort)value;
+
+            return
+                new string(
+                    new[]
+                    {
+                        (char)(result >> 8),
+                        (char)(result & 0xFF)
+                    }
+                );
+        }
+    }
+}

--- a/src/Rocket.Api.Host/Prepopulation/PageTemplates.cs
+++ b/src/Rocket.Api.Host/Prepopulation/PageTemplates.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Rocket.Api.Host.Extensions;
 using Rocket.Domain.Enum;
 using Rocket.Domain.PageTemplates;
 
@@ -24,7 +25,7 @@ namespace Rocket.Api.Host.Prepopulation
 
                 foreach (var productCode in Enum.GetValues<RocketbookProductTypeEnum>())
                 {
-                    var vCode = $"V{(int)productCode:X2}";
+                    var vCode = $"V{productCode.ToCode()}";
 
                     foreach (var rocketbookPageTemplateType in Enum.GetValues<RocketbookPageTemplateTypeEnum>())
                     {

--- a/src/Rocket.Domain/Enum/RocketbookProductTypeEnum.cs
+++ b/src/Rocket.Domain/Enum/RocketbookProductTypeEnum.cs
@@ -2,9 +2,10 @@
 {
     public enum RocketbookProductTypeEnum
     {
-        FusionV16 = 0x16,
-        FusionV1F = 0x1F,
-        CoreV17 = 0x17,
-        CoreV1D = 0x1D
+        FusionV16 = 0x3136,
+        FusionV1F = 0x3146,
+        CoreV17   = 0x3137, 
+        CoreV1D = 0x3144,
+        FlipV1J = 0x314A
     }
 }


### PR DESCRIPTION
Added Rocketbook flip product code ("1J")
Introduced an extension method `ToCode` for `RocketbookProductTypeEnum` to generate product type codes. Updated enum values to match the new encoding scheme and adjusted `PageTemplates` to use the new method for building product codes.