### PR TITLE
fix: add markdown stripping and enhance text extraction logic #89

### DIFF
--- a/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/IMarkdownStripper.cs
+++ b/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/IMarkdownStripper.cs
@@ -1,0 +1,7 @@
+﻿namespace Rocket.Replicate.Infrastructure
+{
+    public interface IMarkdownStripper
+    {
+        string StripFooter(string markdown);
+    }
+}

--- a/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/MarkdownStripper.cs
+++ b/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/MarkdownStripper.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Rocket.Replicate.Infrastructure
+{
+    public class MarkdownStripper : IMarkdownStripper
+    {
+        private static readonly Regex IconRegex =
+            new(
+                @"!\[[^\]]*\]\([^)]*\)\s+[^!]*?(?:icon|qr code)\b",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled
+            );
+
+        public string StripFooter(string markdown)
+        {
+            var result = markdown;
+
+            result =
+                IconRegex
+                    .Replace(
+                        result,
+                        string.Empty
+                    );
+
+            return result;
+        }
+    }
+}

--- a/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/Models/DataLabTo/DataLabToInput.cs
+++ b/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/Models/DataLabTo/DataLabToInput.cs
@@ -22,5 +22,11 @@ namespace Rocket.Replicate.Infrastructure.Models.DataLabTo
         
         [JsonPropertyName("use_llm")]
         public bool UseLlm { get; set; }
+        
+        [JsonPropertyName("skip_cache")]
+        public bool SkipCache { get; set; }
+        
+        [JsonPropertyName("force_ocr")]
+        public bool ForceOcr { get; set; }
     }
 }

--- a/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/Models/DataLabTo/Text/DataLabToExtractTextHook.cs
+++ b/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/Models/DataLabTo/Text/DataLabToExtractTextHook.cs
@@ -14,6 +14,7 @@ namespace Rocket.Replicate.Infrastructure.Models.DataLabTo.Text
 {
     public class DataLabToExtractTextHook(
         IReplicateClient replicateClient,
+        IMarkdownStripper markdownStripper,
         ILogger<DataLabToExtractTextHook> logger
     ) : HookWithConnectorBase<DataLabToExtractTextExecutionStep, ReplicateConnector>(logger), IIntegrationHook
     {
@@ -84,7 +85,11 @@ namespace Rocket.Replicate.Infrastructure.Models.DataLabTo.Text
                                 new DataLabToInput
                                 {
                                     File = imageUrl,
-                                    DisableImageExtraction = true
+                                    DisableImageExtraction = true,
+                                    UseLlm = true,
+                                    SkipCache = true,
+                                    ForceOcr = true,
+                                    IncludeMetadata = false
                                 },
                                 cancellationToken,
                                 DataLabToCustomEndpoint
@@ -108,14 +113,30 @@ namespace Rocket.Replicate.Infrastructure.Models.DataLabTo.Text
                 var extractedText =
                     result?.Markdown ?? string.Empty;
 
-                await
-                    appendLogMessageCallback(
-                        step.Id,
+                logger
+                    .LogDebug(
+                        "Extracted markdown: {extractedText}",
                         extractedText
                     );
 
+                var strippedText =
+                    markdownStripper
+                        .StripFooter(extractedText);
+
+                logger
+                    .LogDebug(
+                        "Stripped markdown: {strippedText}",
+                        strippedText
+                    );
+                
+                await
+                    appendLogMessageCallback(
+                        step.Id,
+                        strippedText
+                    );
+
                 return
-                    extractedText
+                    strippedText
                         .AsCompletedRawTextArtifact();
             }
             finally

--- a/src/Integrations/Replicate/Rocket.Replicate.Injection.Api/ServiceCollectionExtension.cs
+++ b/src/Integrations/Replicate/Rocket.Replicate.Injection.Api/ServiceCollectionExtension.cs
@@ -41,6 +41,7 @@ namespace Rocket.Replicate.Injection.Api
             services
                 .AddTransient<IConnectorModelMapper, ReplicateConnectorMapper>()
                 .AddTransient<IBsonMapper, ReplicateBsonMapper>()
+                .AddTransient<IMarkdownStripper, MarkdownStripper>()
                 .AddTransient<IReplicateClient, ReplicateClient>();
 
             services


### PR DESCRIPTION
Introduced `IMarkdownStripper` interface and its implementation to remove unwanted markdown footers. Updated text extraction logic to strip markdown and added new properties (`SkipCache`, `ForceOcr`, etc.) to improve flexibility. Registered the markdown stripper in the service container for dependency injection.