### PR TITLE
feat: add LLM timeout configuration to global settings #92

### DIFF
--- a/src/Integrations/Google/Gcp/Rocket.Gcp.Infrastructure/GcpOcrExtractHook.cs
+++ b/src/Integrations/Google/Gcp/Rocket.Gcp.Infrastructure/GcpOcrExtractHook.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Rocket.Domain.Executions;
 using Rocket.Domain.Jobs;
+using Rocket.Domain.Utils;
 using Rocket.Gcp.Domain;
 using Rocket.Integrations.Common;
 using Rocket.Integrations.Common.Extensions;
@@ -13,6 +14,7 @@ namespace Rocket.Gcp.Infrastructure
 {
     public class GcpOcrExtractHook(
         IVisionOcrService visionOcrService,
+        IGlobalSettingsRepository globalSettingsRepository,
         ILogger<GcpOcrExtractHook> logger
     )
         : HookWithConnectorBase<GcpExtractExecutionStep, GcpConnector>(logger), IIntegrationHook
@@ -44,6 +46,15 @@ namespace Rocket.Gcp.Infrastructure
             var credential =
                 Connector
                     .Credential;
+            
+            var globalSettings =
+                await
+                    globalSettingsRepository
+                        .GetGlobalSettingsAsync(cancellationToken);
+
+            var timeoutInMinutes =
+                globalSettings?.DefaultModelTimeoutInMinutes ??
+                DomainConstants.GlobalDefaultModelTimeoutInMinutes;
 
             var result =
                 await
@@ -51,6 +62,7 @@ namespace Rocket.Gcp.Infrastructure
                         .ExtractHandwrittenTextAsync(
                             imageBytes,
                             credential,
+                            timeoutInMinutes,
                             cancellationToken
                         );
 

--- a/src/Integrations/Google/Gcp/Rocket.Gcp.Infrastructure/IVisionOcrService.cs
+++ b/src/Integrations/Google/Gcp/Rocket.Gcp.Infrastructure/IVisionOcrService.cs
@@ -9,6 +9,7 @@ namespace Rocket.Gcp.Infrastructure
         Task<string> ExtractHandwrittenTextAsync(
             byte[] imageBytes,
             GcpCredential gcpCredential,
+            int timeoutInMinutes,
             CancellationToken cancellationToken
         );
     }

--- a/src/Integrations/Google/Gcp/Rocket.Gcp.Infrastructure/VisionOcrService.cs
+++ b/src/Integrations/Google/Gcp/Rocket.Gcp.Infrastructure/VisionOcrService.cs
@@ -1,9 +1,13 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
 using Google.Apis.Auth.OAuth2;
 using Google.Cloud.Vision.V1;
+using Grpc.Core;
 using Rocket.Gcp.Domain;
 
 namespace Rocket.Gcp.Infrastructure
@@ -13,6 +17,7 @@ namespace Rocket.Gcp.Infrastructure
         public async Task<string> ExtractHandwrittenTextAsync(
             byte[] imageBytes,
             GcpCredential gcpCredential,
+            int timeoutInMinutes,
             CancellationToken cancellationToken
         )
         {
@@ -47,18 +52,41 @@ namespace Rocket.Gcp.Infrastructure
                         .BuildAsync(cancellationToken);
 
             // Load the image and perform OCR
-            var image = 
+            var image =
                 Image
                     .FromBytes(imageBytes);
 
-            var response =
-                await
-                    client
-                        .DetectDocumentTextAsync(image);
+            try
+            {
+                var response =
+                    await
+                        client
+                            .DetectDocumentTextAsync(
+                                image,
+                                null,
+                                CallSettings
+                                    .FromExpiration(
+                                        Expiration
+                                            .FromTimeout(
+                                                TimeSpan
+                                                    .FromMinutes(timeoutInMinutes)
+                                            )
+                                    )
+                            );
 
-            return
-                response
-                    .Text;
+                return
+                    response
+                        .Text;
+            }
+            catch (RpcException ex)
+            {
+                if (ex.StatusCode == StatusCode.DeadlineExceeded)
+                {
+                    throw new OperationCanceledException();
+                }
+
+                throw;
+            }
         }
     }
 }

--- a/src/Integrations/Ollama/Rocket.Ollama.Infrastructure/IOllamaClient.cs
+++ b/src/Integrations/Ollama/Rocket.Ollama.Infrastructure/IOllamaClient.cs
@@ -22,6 +22,7 @@ namespace Rocket.Ollama.Infrastructure
             float? temperature,
             int? maxTokens,
             int? numCtx,
+            int timeoutInMinutes,
             CancellationToken cancellationToken
         ) where T : class;
     }

--- a/src/Integrations/Ollama/Rocket.Ollama.Infrastructure/OllamaClient.cs
+++ b/src/Integrations/Ollama/Rocket.Ollama.Infrastructure/OllamaClient.cs
@@ -61,19 +61,19 @@ namespace Rocket.Ollama.Infrastructure
             return results;
         }
 
-        public async Task<T>
-            SendRequestAsync<T>(
-                string endpoint,
-                string modelName,
-                string prompt,
-                byte[] imageBytes,
-                RocketbookPageTemplateTypeEnum pageTemplateType,
-                bool useSchema,
-                float? temperature,
-                int? maxTokens,
-                int? numCtx,
-                CancellationToken cancellationToken
-            ) where T : class
+        public async Task<T> SendRequestAsync<T>(
+            string endpoint,
+            string modelName,
+            string prompt,
+            byte[] imageBytes,
+            RocketbookPageTemplateTypeEnum pageTemplateType,
+            bool useSchema,
+            float? temperature,
+            int? maxTokens,
+            int? numCtx,
+            int timeoutInMinutes,
+            CancellationToken cancellationToken
+        ) where T : class
         {
             string base64Image = null;
 
@@ -90,7 +90,7 @@ namespace Rocket.Ollama.Infrastructure
 
             httpClient.Timeout =
                 TimeSpan
-                    .FromMinutes(10);
+                    .FromMinutes(timeoutInMinutes);
 
             logger
                 .LogDebug("Ollama prompt:\r\n{prompt}", prompt);

--- a/src/Integrations/Ollama/Rocket.Ollama.Infrastructure/Project/OllamaExtractProjectHook.cs
+++ b/src/Integrations/Ollama/Rocket.Ollama.Infrastructure/Project/OllamaExtractProjectHook.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Rocket.Domain.Enum;
 using Rocket.Domain.Executions;
 using Rocket.Domain.Jobs;
+using Rocket.Domain.Utils;
 using Rocket.Integrations.Common.Extensions;
 using Rocket.Interfaces;
 using Rocket.Ollama.Domain;
@@ -17,6 +18,7 @@ namespace Rocket.Ollama.Infrastructure.Project
 {
     public class OllamaExtractProjectHook(
         IOllamaClient ollamaClient,
+        IGlobalSettingsRepository globalSettingsRepository,
         ILogger<OllamaExtractProjectHook> logger
     )
         : OllamaHookBase<OllamaExtractProjectExecutionStep, OllamaConnector>(
@@ -72,6 +74,15 @@ namespace Rocket.Ollama.Infrastructure.Project
                     ExecutionStep.FirstPassModelName,
                     ExecutionStep.SecondPassModelName
                 );
+            
+            var globalSettings =
+                await
+                    globalSettingsRepository
+                        .GetGlobalSettingsAsync(cancellationToken);
+
+            var timeoutInMinutes =
+                globalSettings?.DefaultModelTimeoutInMinutes ??
+                DomainConstants.GlobalDefaultModelTimeoutInMinutes;
 
             var firstPassResponse =
                 await
@@ -86,7 +97,8 @@ namespace Rocket.Ollama.Infrastructure.Project
                             temperature: 0.1F,
                             maxTokens: 1024,
                             numCtx: null,
-                            cancellationToken
+                            timeoutInMinutes,
+                            cancellationToken: cancellationToken
                         );
 
             var secondPassResponse =
@@ -100,12 +112,13 @@ namespace Rocket.Ollama.Infrastructure.Project
                                 firstPassResponse
                             ),
                             imageBytes: null,
-                            RocketbookPageTemplateTypeEnum.ProjectTaskTracker,
+                            pageTemplateType: RocketbookPageTemplateTypeEnum.ProjectTaskTracker,
                             useSchema: true,
                             temperature: 0.3F,
                             maxTokens: 1024,
                             numCtx: 4096,
-                            cancellationToken
+                            timeoutInMinutes,
+                            cancellationToken: cancellationToken
                         );
 
             await

--- a/src/Integrations/Ollama/Rocket.Ollama.Infrastructure/Text/OllamaExtractTextHook.cs
+++ b/src/Integrations/Ollama/Rocket.Ollama.Infrastructure/Text/OllamaExtractTextHook.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Rocket.Domain.Enum;
 using Rocket.Domain.Executions;
 using Rocket.Domain.Jobs;
+using Rocket.Domain.Utils;
 using Rocket.Integrations.Common.Extensions;
 using Rocket.Interfaces;
 using Rocket.Ollama.Domain;
@@ -16,6 +17,7 @@ namespace Rocket.Ollama.Infrastructure.Text
 {
     public class OllamaExtractTextHook(
         IOllamaClient ollamaClient,
+        IGlobalSettingsRepository globalSettingsRepository,
         ILogger<OllamaExtractTextHook> logger
     )
         : OllamaHookBase<OllamaExtractTextExecutionStep, OllamaConnector>(
@@ -61,6 +63,15 @@ namespace Rocket.Ollama.Infrastructure.Text
                     ExecutionStep.ModelName
                 );
 
+            var globalSettings =
+                await
+                    globalSettingsRepository
+                        .GetGlobalSettingsAsync(cancellationToken);
+
+            var timeoutInMinutes =
+                globalSettings?.DefaultModelTimeoutInMinutes ??
+                DomainConstants.GlobalDefaultModelTimeoutInMinutes;
+
             var response =
                 await
                     OllamaClient
@@ -74,6 +85,7 @@ namespace Rocket.Ollama.Infrastructure.Text
                             null,
                             null,
                             null,
+                            timeoutInMinutes,
                             cancellationToken
                         );
 

--- a/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/IReplicateClient.cs
+++ b/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/IReplicateClient.cs
@@ -25,15 +25,15 @@ namespace Rocket.Replicate.Infrastructure
         Task<T> WaitUntilPredictionCompletesAsync<T>(
             string apiToken,
             string predictionId,
-            CancellationToken cancellationToken,
-            int timeoutInSeconds = 300
+            int timeoutInMinutes,
+            CancellationToken cancellationToken
         ) where T : IReplicateOutput;
 
         Task<string> WaitUntilPredictionCompletesAsync(
             string apiToken,
             string predictionId,
-            CancellationToken cancellationToken,
-            int timeoutInSeconds = 300
+            int timeoutInMinutes,
+            CancellationToken cancellationToken
         );
 
         Task DeleteUploadAsync(string apiToken, string fileId);

--- a/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/Models/DataLabTo/Project/DataLabToExtractProjectHook.cs
+++ b/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/Models/DataLabTo/Project/DataLabToExtractProjectHook.cs
@@ -7,6 +7,7 @@ using Rocket.Domain.Enum;
 using Rocket.Domain.Exceptions;
 using Rocket.Domain.Executions;
 using Rocket.Domain.Jobs;
+using Rocket.Domain.Utils;
 using Rocket.Integrations.Common;
 using Rocket.Integrations.Common.Extensions;
 using Rocket.Interfaces;
@@ -18,6 +19,7 @@ namespace Rocket.Replicate.Infrastructure.Models.DataLabTo.Project
 {
     public class DataLabToExtractProjectHook(
         ISchemaResponseBuilder schemaResponseBuilder,
+        IGlobalSettingsRepository globalSettingsRepository,
         IReplicateClient replicateClient,
         ILogger<DataLabToExtractProjectHook> logger
     ) : HookWithConnectorBase<DataLabToExtractProjectExecutionStep, ReplicateConnector>(logger), IIntegrationHook
@@ -129,12 +131,22 @@ namespace Rocket.Replicate.Infrastructure.Models.DataLabTo.Project
                         predictionId
                     );
 
+                var globalSettings =
+                    await
+                        globalSettingsRepository
+                            .GetGlobalSettingsAsync(cancellationToken);
+
+                var timeoutInMinutes =
+                    globalSettings?.DefaultModelTimeoutInMinutes ??
+                    DomainConstants.GlobalDefaultModelTimeoutInMinutes;
+                
                 var result =
                     await
                         replicateClient
                             .WaitUntilPredictionCompletesAsync<DataLabToOutput>(
                                 apiToken,
                                 predictionId,
+                                timeoutInMinutes,
                                 cancellationToken
                             );
 

--- a/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/Models/DataLabTo/Text/DataLabToExtractTextHook.cs
+++ b/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/Models/DataLabTo/Text/DataLabToExtractTextHook.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Rocket.Domain.Executions;
 using Rocket.Domain.Jobs;
+using Rocket.Domain.Utils;
 using Rocket.Integrations.Common;
 using Rocket.Integrations.Common.Extensions;
 using Rocket.Interfaces;
@@ -15,6 +16,7 @@ namespace Rocket.Replicate.Infrastructure.Models.DataLabTo.Text
     public class DataLabToExtractTextHook(
         IReplicateClient replicateClient,
         IMarkdownStripper markdownStripper,
+        IGlobalSettingsRepository globalSettingsRepository,
         ILogger<DataLabToExtractTextHook> logger
     ) : HookWithConnectorBase<DataLabToExtractTextExecutionStep, ReplicateConnector>(logger), IIntegrationHook
     {
@@ -101,12 +103,22 @@ namespace Rocket.Replicate.Infrastructure.Models.DataLabTo.Text
                         predictionId
                     );
 
+                var globalSettings =
+                    await
+                        globalSettingsRepository
+                            .GetGlobalSettingsAsync(cancellationToken);
+
+                var timeoutInMinutes =
+                    globalSettings?.DefaultModelTimeoutInMinutes ??
+                    DomainConstants.GlobalDefaultModelTimeoutInMinutes;
+                
                 var result =
                     await
                         replicateClient
                             .WaitUntilPredictionCompletesAsync<DataLabToOutput>(
                                 apiToken,
                                 predictionId,
+                                timeoutInMinutes,
                                 cancellationToken
                             );
 

--- a/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/Models/DeepSeekOcr/DeepSeekOcrExtractTextHook.cs
+++ b/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/Models/DeepSeekOcr/DeepSeekOcrExtractTextHook.cs
@@ -7,6 +7,7 @@ using Rocket.Domain.Enum;
 using Rocket.Domain.Exceptions;
 using Rocket.Domain.Executions;
 using Rocket.Domain.Jobs;
+using Rocket.Domain.Utils;
 using Rocket.Interfaces;
 using Rocket.Replicate.Domain;
 using Rocket.Replicate.Domain.Models.DeepSeekOcr;
@@ -15,6 +16,7 @@ namespace Rocket.Replicate.Infrastructure.Models.DeepSeekOcr
 {
     public class DeepSeekOcrExtractTextHook(
         ILogger<DeepSeekOcrExtractTextHook> logger,
+        IGlobalSettingsRepository globalSettingsRepository,
         IReplicateClient replicateClient
     ) : IIntegrationHook
     {
@@ -95,12 +97,22 @@ namespace Rocket.Replicate.Infrastructure.Models.DeepSeekOcr
                 logger
                     .LogInformation("Created prediction in Replicate: {predictionId}", predictionId);
 
+                var globalSettings =
+                    await
+                        globalSettingsRepository
+                            .GetGlobalSettingsAsync(cancellationToken);
+
+                var timeoutInMinutes =
+                    globalSettings?.DefaultModelTimeoutInMinutes ??
+                    DomainConstants.GlobalDefaultModelTimeoutInMinutes;
+                
                 var result =
                     await
                         replicateClient
                             .WaitUntilPredictionCompletesAsync(
                                 apiToken,
                                 predictionId,
+                                timeoutInMinutes,
                                 cancellationToken
                             );
 

--- a/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/ReplicateClient.cs
+++ b/src/Integrations/Replicate/Rocket.Replicate.Infrastructure/ReplicateClient.cs
@@ -157,38 +157,40 @@ namespace Rocket.Replicate.Infrastructure
         public async Task<string> WaitUntilPredictionCompletesAsync(
             string apiToken,
             string predictionId,
-            CancellationToken cancellationToken,
-            int timeoutInSeconds = 300
+            int timeoutInMinutes,
+            CancellationToken cancellationToken
         ) =>
             await
                 GetPredictionStatusAsync<string>(
                     apiToken,
                     predictionId,
-                    cancellationToken,
-                    timeoutInSeconds
+                    timeoutInMinutes,
+                    cancellationToken
                 );
 
         public async Task<T> WaitUntilPredictionCompletesAsync<T>(
             string apiToken,
             string predictionId,
-            CancellationToken cancellationToken,
-            int timeoutInSeconds = 300
+            int timeoutInMinutes,
+            CancellationToken cancellationToken
         ) where T : IReplicateOutput =>
             await
                 GetPredictionStatusAsync<T>(
                     apiToken,
                     predictionId,
-                    cancellationToken,
-                    timeoutInSeconds
+                    timeoutInMinutes,
+                    cancellationToken
                 );
 
         private async Task<T> GetPredictionStatusAsync<T>(
             string apiToken,
             string predictionId,
-            CancellationToken cancellationToken,
-            int timeoutInSeconds = 300
+            int timeoutInMinutes,
+            CancellationToken cancellationToken
         )
         {
+            var timeoutInSeconds = timeoutInMinutes * 60;
+            
             // loop (this is a background job so patience is OK)
             var status =
                 ReplicateDomainConstants
@@ -216,7 +218,7 @@ namespace Rocket.Replicate.Infrastructure
             {
                 if (stopwatch.Elapsed.TotalSeconds > timeoutInSeconds)
                     throw new RocketException(
-                        $"The Replicate prediction timed out ({timeoutInSeconds} seconds).",
+                        $"The Replicate prediction timed out after {timeoutInMinutes} minutes.",
                         ApiStatusCodeEnum.ThirdPartyServiceError
                     );
 

--- a/src/Rocket.Api.Contracts/GlobalSettings/GlobalSettingsSpecifics.cs
+++ b/src/Rocket.Api.Contracts/GlobalSettings/GlobalSettingsSpecifics.cs
@@ -9,5 +9,8 @@ namespace Rocket.Api.Contracts.GlobalSettings
 
         [JsonPropertyName("enable_sweeping")]
         public bool? EnableSweeping { get; set; }
+        
+        [JsonPropertyName("default_model_timeout_in_minutes")]
+        public int? DefaultModelTimeoutInMinutes { get; set; }
     }
 }

--- a/src/Rocket.Api.Host/Controllers/GlobalSettingsController.cs
+++ b/src/Rocket.Api.Host/Controllers/GlobalSettingsController.cs
@@ -64,7 +64,8 @@ namespace Rocket.Api.Host.Controllers
                 new GlobalSettingsSpecifics
                 {
                     SweepSuccessfulScansAfterDays = record.SweepSuccessfulScansAfterDays,
-                    EnableSweeping = record.EnableSweeping
+                    EnableSweeping = record.EnableSweeping,
+                    DefaultModelTimeoutInMinutes = record.DefaultModelTimeoutInMinutes
                 };
 
             return
@@ -108,7 +109,8 @@ namespace Rocket.Api.Host.Controllers
                 globalSettingsRepository
                     .UpdateGlobalSettingsAsync(
                         request.SweepSuccessfulScansAfterDays,
-                        request.EnableSweeping,
+                        request.EnableSweeping, 
+                        request.DefaultModelTimeoutInMinutes,
                         cancellationToken
                     );
 

--- a/src/Rocket.Domain/GlobalSettings.cs
+++ b/src/Rocket.Domain/GlobalSettings.cs
@@ -12,5 +12,7 @@ namespace Rocket.Domain
         public int SweepSuccessfulScansAfterDays { get; set; }
 
         public bool EnableSweeping { get; set; }
+
+        public int? DefaultModelTimeoutInMinutes { get; set; }
     }
 }

--- a/src/Rocket.Domain/Utils/DomainConstants.cs
+++ b/src/Rocket.Domain/Utils/DomainConstants.cs
@@ -49,5 +49,6 @@ namespace Rocket.Domain.Utils
             { (int)BookVendorTypeEnum.Rocketbook, "Rocketbook" }
         };
 
+        public const int GlobalDefaultModelTimeoutInMinutes = 10;
     }
 }

--- a/src/Rocket.Infrastructure.Db.Mongo/MongoDbGlobalSettingsRepository.cs
+++ b/src/Rocket.Infrastructure.Db.Mongo/MongoDbGlobalSettingsRepository.cs
@@ -23,12 +23,14 @@ namespace Rocket.Infrastructure.Db.Mongo
             new()
             {
                 { nameof(GlobalSettings.SweepSuccessfulScansAfterDays), 10 },
-                { nameof(GlobalSettings.EnableSweeping), true }
+                { nameof(GlobalSettings.EnableSweeping), true },
+                { nameof(GlobalSettings.DefaultModelTimeoutInMinutes), (int?)null }
             };
 
         public async Task UpdateGlobalSettingsAsync(
             int? sweepSuccessfulScansAfterDays,
             bool? enableSweeping,
+            int? defaultModelTimeoutInMinutes,
             CancellationToken cancellationToken
         )
         {
@@ -64,9 +66,20 @@ namespace Rocket.Infrastructure.Db.Mongo
                     );
             }
 
+            updates
+                .Add(
+                    updateBuilder
+                        .Set(
+                            o => o.DefaultModelTimeoutInMinutes,
+                            defaultModelTimeoutInMinutes
+                        )
+                );
+
             if (updates.Count == 0) return;
 
-            var combinedUpdate = updateBuilder.Combine(updates);
+            var combinedUpdate =
+                updateBuilder
+                    .Combine(updates);
 
             var collection =
                 GetMongoCollection();

--- a/src/Rocket.Interfaces/IGlobalSettingsRepository.cs
+++ b/src/Rocket.Interfaces/IGlobalSettingsRepository.cs
@@ -13,6 +13,7 @@ namespace Rocket.Interfaces
         Task UpdateGlobalSettingsAsync(
             int? sweepSuccessfulScansAfterDays,
             bool? enableSweeping,
+            int? defaultModelTimeoutInMinutes,
             CancellationToken cancellationToken
         );
     }

--- a/src/Rocket.Web.Host/Components/Pages/GlobalSettings/GlobalSettingsDetails.razor
+++ b/src/Rocket.Web.Host/Components/Pages/GlobalSettings/GlobalSettingsDetails.razor
@@ -64,6 +64,37 @@
                             </MudGrid>
                         </div>
                     </MudItem>
+                    <MudItem xs="12">
+                        <div class="mud-border-primary border p-4 mb-4 rounded">
+                            <MudGrid>
+                                <MudItem xs="12">
+                                    <MudText
+                                        Color="Color.Secondary"
+                                        GutterBottom
+                                        Typo="Typo.h5">
+                                        LLM timeout
+                                    </MudText>
+                                    <MudText
+                                        Typo="Typo.body2">
+                                        <p>
+                                            Configure the timeout (in minutes) for LLM operations (i.e. OCR extraction from models).
+                                        </p>
+                                        <p>
+                                            If left empty, the default timeout is 10 minutes.
+                                        </p>
+                                    </MudText>
+                                </MudItem>
+                                <MudItem xs="6">
+                                    <MudNumericField
+                                        @bind-Value="_newModel.DefaultModelTimeoutInMinutes"
+                                        Label="Model timeout (in minutes)"
+                                        Min="1"
+                                        Clearable
+                                        OnlyValidateIfDirty/>
+                                </MudItem>
+                            </MudGrid>
+                        </div>
+                    </MudItem>
                 </MudGrid>
                 <MudGrid Class="align-start" Justify="Justify.FlexEnd">
                     <MudItem>
@@ -114,7 +145,8 @@
                 new GlobalSettingsSpecifics
                 {
                     SweepSuccessfulScansAfterDays = _currentModel.SweepSuccessfulScansAfterDays,
-                    EnableSweeping = _currentModel.EnableSweeping
+                    EnableSweeping = _currentModel.EnableSweeping,
+                    DefaultModelTimeoutInMinutes = _currentModel.DefaultModelTimeoutInMinutes
                 };
         }
         catch (Exception ex)
@@ -144,6 +176,7 @@
             {
                 var sweepSuccessfulScansAfterDaysValue = _newModel.SweepSuccessfulScansAfterDays;
                 var enableSweepingValue = _newModel.EnableSweeping;
+                var defaultModelTimeoutInMinutes = _newModel.DefaultModelTimeoutInMinutes;
 
                 await
                     ApiRequestManager
@@ -151,7 +184,8 @@
                             new GlobalSettingsSpecifics
                             {
                                 SweepSuccessfulScansAfterDays = sweepSuccessfulScansAfterDaysValue,
-                                EnableSweeping = enableSweepingValue
+                                EnableSweeping = enableSweepingValue,
+                                DefaultModelTimeoutInMinutes = defaultModelTimeoutInMinutes
                             },
                             BaseCancellationToken
                         );
@@ -160,7 +194,8 @@
                     new GlobalSettingsSpecifics
                     {
                         SweepSuccessfulScansAfterDays = sweepSuccessfulScansAfterDaysValue ?? _currentModel.SweepSuccessfulScansAfterDays,
-                        EnableSweeping = enableSweepingValue ?? _currentModel.EnableSweeping
+                        EnableSweeping = enableSweepingValue ?? _currentModel.EnableSweeping,
+                        DefaultModelTimeoutInMinutes = _currentModel.DefaultModelTimeoutInMinutes
                     };
 
                 Snackbar


### PR DESCRIPTION
Introduced a configurable timeout value for LLM operations across various integrations, defaulting to 10 minutes if unspecified. Updated related APIs, repositories, and UI components to support this feature, ensuring consistent timeout behavior.