### PR TITLE
fix: move curl installation to final stage in Dockerfile #104

### DIFF
--- a/src/Rocket.Api.Host/Dockerfile
+++ b/src/Rocket.Api.Host/Dockerfile
@@ -1,5 +1,4 @@
 ﻿FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
@@ -15,6 +14,7 @@ RUN \
     dotnet publish "./Rocket.Api.Host/Rocket.Api.Host.csproj" --ignore-failed-sources --no-restore -c Release -o /app/publish -a $TARGETARCH /p:UseAppHost=false
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 ARG APP_VERSION=0.0.0
 ENV APP_VERSION=$APP_VERSION


### PR DESCRIPTION
Relocated the curl installation command to the final stage to optimize the build process. This reduces unnecessary steps in the base stage and ensures curl is only available in the final image where needed.