### PR TITLE
feat: add vendor field support across scan-related components #106

### DIFF
--- a/src/Rocket.Api.Contracts/Scans/ScanSpecifics.cs
+++ b/src/Rocket.Api.Contracts/Scans/ScanSpecifics.cs
@@ -31,5 +31,8 @@ namespace Rocket.Api.Contracts.Scans
 
         [JsonPropertyName("archived")]
         public bool Archived { get; set; }
+
+        [JsonPropertyName("vendor")]
+        public string Vendor { get; set; }
     }
 }

--- a/src/Rocket.Api.Host/Controllers/CaptureController.cs
+++ b/src/Rocket.Api.Host/Controllers/CaptureController.cs
@@ -114,6 +114,7 @@ namespace Rocket.Api.Host.Controllers
                                 userId,
                                 model.QrCode,
                                 model.QrBoundingBox,
+                                model.Vendor,
                                 cancellationToken
                             );
 
@@ -158,6 +159,9 @@ namespace Rocket.Api.Host.Controllers
 
             [FromForm(Name = "qr_bounding_box")]
             public string QrBoundingBox { get; set; }
+
+            [FromForm(Name = "vendor")]
+            public string Vendor { get; set; }
         }
     }
 }

--- a/src/Rocket.Api.Host/Controllers/ScansController.cs
+++ b/src/Rocket.Api.Host/Controllers/ScansController.cs
@@ -153,7 +153,8 @@ namespace Rocket.Api.Host.Controllers
                     FileExtension = record.FileExtension,
                     Sha256 = record.Sha256,
                     ImageBase64 = Convert.ToBase64String(imageData),
-                    Archived = record.Archived
+                    Archived = record.Archived,
+                    Vendor = record.Vendor
                 };
 
             return

--- a/src/Rocket.Domain/ScannedImage.cs
+++ b/src/Rocket.Domain/ScannedImage.cs
@@ -29,5 +29,7 @@ namespace Rocket.Domain
         public string ThumbnailBase64 { get; set; }
 
         public bool Archived { get; set; }
+        
+        public string Vendor { get; set; }
     }
 }

--- a/src/Rocket.Infrastructure/ScannedImageHandler.cs
+++ b/src/Rocket.Infrastructure/ScannedImageHandler.cs
@@ -24,6 +24,7 @@ namespace Rocket.Infrastructure
             string userId,
             string qrCode,
             string qrBoundingBox,
+            string vendor,
             CancellationToken cancellationToken
         )
         {
@@ -71,6 +72,7 @@ namespace Rocket.Infrastructure
                 scannedImage.QrCode = qrCode;
                 scannedImage.QrBoundingBox = qrBoundingBox;
                 scannedImage.Archived = false;
+                scannedImage.Vendor = vendor;
 
                 var result =
                     await

--- a/src/Rocket.Interfaces/IScannedImageHandler.cs
+++ b/src/Rocket.Interfaces/IScannedImageHandler.cs
@@ -13,6 +13,7 @@ namespace Rocket.Interfaces
             string userId,
             string qrCode,
             string qrBoundingBox,
+            string vendor,
             CancellationToken cancellationToken
         );
 

--- a/src/Rocket.Web.Host/Components/Pages/Scans/ScanDetails.razor
+++ b/src/Rocket.Web.Host/Components/Pages/Scans/ScanDetails.razor
@@ -68,6 +68,10 @@
                                     Value=@(_scanSpecifics.Archived ? "Archived" : "Active")
                                     ValueColor="@(_scanSpecifics.Archived ? Color.Warning : Color.Success)"
                                 />
+                                <SimpleTableRowPair
+                                    Title="Vendor"
+                                    Value=@(string.IsNullOrEmpty(_scanSpecifics.Vendor) ? "Unknown" : _scanSpecifics.Vendor)
+                                />
                                 </tbody>
                             </MudSimpleTable>
                         </div>


### PR DESCRIPTION
Introduce the "vendor" field to scan entities, APIs, and UI components. This change ensures consistent handling and display of vendor information throughout all relevant layers of the application.