### PR TITLE
feat: add file download functionality for scan details #136

### DIFF
--- a/src/Rocket.Web.Host/Components/App.razor
+++ b/src/Rocket.Web.Host/Components/App.razor
@@ -21,6 +21,7 @@
 <script src="_content/MudBlazor/MudBlazor.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/blazor.mermaid.js"></script>
+<script src="js/download.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
 <script>
     initializeMermaid();

--- a/src/Rocket.Web.Host/Components/Pages/Scans/ScanDetails.razor
+++ b/src/Rocket.Web.Host/Components/Pages/Scans/ScanDetails.razor
@@ -9,6 +9,7 @@
 @inject IWebHostErrorHandler WebHostErrorHandler
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
+@inject IJSRuntime JsRuntime
 @inherits Rocket.Web.Host.Infrastructure.BaseSecureCancellableComponent
 
 <BottleRocketLoadingOverlay IsLoading="@_isLoading">
@@ -25,7 +26,7 @@
                                 Class="broken-image"
                                 Icon="@StandardIcons.NoImageIcon"
                                 Title="Scan has been archived"/>
-                            
+
                             <MudText
                                 Typo="Typo.h4"
                                 Class="broken-image"
@@ -117,7 +118,20 @@
                             </div>
                         }
                         <MudDivider/>
-                        <GoBackButton BackPath="/MyScans"/>
+                        <MudGrid Class="align-start" Justify="Justify.FlexEnd">
+                            <MudItem>
+                                <GoBackButton BackPath="/MyScans"/>
+                            </MudItem>
+                            <MudItem>
+                                <MudButton
+                                    Variant="Variant.Outlined"
+                                    Color="Color.Info"
+                                    Disabled="@(_scanSpecifics.Archived)"
+                                    OnClick="@(async () => await DownloadFileAsync())">
+                                    Download
+                                </MudButton>
+                            </MudItem>
+                        </MudGrid>
                     </MudStack>
                 </MudItem>
                 <MudFlexBreak/>
@@ -276,6 +290,48 @@
                 _isLoading = false;
                 StateHasChanged();
             }
+        }
+    }
+
+    private async Task DownloadFileAsync()
+    {
+        try
+        {
+            var fileName = _scanSpecifics.Id;
+            var contentType = _scanSpecifics.ContentType;
+
+            var base64Data = _scanSpecifics?.ImageBase64;
+
+            if (!string.IsNullOrEmpty(base64Data))
+            {
+                if (base64Data.Contains(","))
+                {
+                    base64Data = base64Data.Split(',')[1];
+                }
+
+                await
+                    JsRuntime
+                        .InvokeVoidAsync(
+                            "downloadBase64File",
+                            fileName,
+                            contentType,
+                            base64Data
+                        );
+            }
+            else
+            {
+                throw new Exception("No file data could be provided for download.");
+            }
+        }
+        catch (Exception ex)
+        {
+            WebHostErrorHandler
+                .HandleException(ex);
+        }
+        finally
+        {
+            _isLoading = false;
+            StateHasChanged();
         }
     }
 

--- a/src/Rocket.Web.Host/wwwroot/js/download.js
+++ b/src/Rocket.Web.Host/wwwroot/js/download.js
@@ -1,0 +1,9 @@
+﻿function downloadBase64File(filename, contentType, base64Data) {
+    const linkSource = `data:${contentType};base64,${base64Data}`;
+
+    const downloadLink = document.createElement("a");
+    downloadLink.href = linkSource;
+    downloadLink.download = filename;
+
+    downloadLink.click();
+}


### PR DESCRIPTION
Introduced a feature to download scan files as Base64-encoded data. Added a JavaScript function for handling file downloads and integrated it into the ScanDetails page with a new download button. Updated the App.razor to include the required script.